### PR TITLE
Add detailed diff to the assertAlphaEqual

### DIFF
--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -921,10 +921,7 @@ pub struct BindingsSet(smallvec::SmallVec<[Bindings; 1]>);
 // BindingsSets are conceptually unordered
 impl PartialEq for BindingsSet {
     fn eq(&self, other: &Self) -> bool {
-        match crate::common::assert::vec_eq_no_order(self.iter(), other.iter()) {
-            Ok(()) => true,
-            Err(_) => false
-        }
+        !crate::common::assert::compare_vec_no_order(self.iter(), other.iter(), crate::common::collections::DefaultEquality{}).has_diff()
     }
 }
 

--- a/lib/src/common/assert.rs
+++ b/lib/src/common/assert.rs
@@ -1,50 +1,105 @@
-use super::collections::ListMap;
+use super::collections::{ListMap, Equality, DefaultEquality};
 
 use std::cmp::Ordering;
 
-pub fn vec_eq_no_order<'a, T: PartialEq + std::fmt::Debug + 'a, A: Iterator<Item=&'a T>, B: Iterator<Item=&'a T>>(left: A, right: B) -> Result<(), String> {
-    let mut left_count: ListMap<&T, usize> = ListMap::new();
-    let mut right_count: ListMap<&T, usize> = ListMap::new();
+pub fn vec_eq_no_order<'a, T, A, B>(left: A, right: B) -> Option<String>
+where
+    T: 'a + PartialEq + std::fmt::Debug,
+    A: Iterator<Item=&'a T>,
+    B: Iterator<Item=&'a T>,
+{
+    compare_vec_no_order(left, right, DefaultEquality{}).as_string()
+}
+
+pub fn compare_vec_no_order<'a, T, A, B, E>(left: A, right: B, _cmp: E) -> VecDiff<'a, T, E>
+where
+    A: Iterator<Item=&'a T>,
+    B: Iterator<Item=&'a T>,
+    E: Equality<&'a T>,
+{
+    let mut left_count: ListMap<&T, usize, E> = ListMap::new();
+    let mut right_count: ListMap<&T, usize, E> = ListMap::new();
     for i in left {
         *left_count.entry(&i).or_insert(0) += 1;
     }
     for i in right {
         *right_count.entry(&i).or_insert(0) += 1;
     }
-    counter_eq_explanation(&left_count, &right_count)
+    VecDiff{ left_count, right_count }
 }
 
-fn counter_eq_explanation<T: PartialEq + std::fmt::Debug>(left: &ListMap<&T, usize>, right: &ListMap<&T, usize>) -> Result<(), String> {
-    for e in right.iter() {
-        if let Some(count) = left.get(e.0) {
-            match count.cmp(e.1) {
-                Ordering::Less => return Err(format!("Missed result: {:?}", e.0)),
-                Ordering::Greater => return Err(format!("Excessive result: {:?}", e.0)),
-                Ordering::Equal => {},
+pub struct VecDiff<'a, T, E: Equality<&'a T>> {
+    left_count: ListMap<&'a T, usize, E>,
+    right_count: ListMap<&'a T, usize, E>,
+}
+
+trait DiffVisitor<'a, T> {
+    fn diff(&mut self, item: &'a T, left: usize, right: usize) -> bool;
+}
+
+impl<'a, T: std::fmt::Debug, E: Equality<&'a T>> VecDiff<'a, T, E> {
+    pub fn has_diff(&self) -> bool {
+        #[derive(Default)]
+        struct FindDiff {
+            diff: bool,
+        }
+        impl<T: std::fmt::Debug> DiffVisitor<'_, T> for FindDiff {
+            fn diff(&mut self, _item: &T, left: usize, right: usize) -> bool {
+                if left == right {
+                    false
+                } else {
+                    self.diff = true;
+                    true
+                }
             }
-        } else {
-            return Err(format!("Missed result: {:?}", e.0));
+        }
+        let mut f = FindDiff::default();
+        self.visit(&mut f);
+        f.diff
+    }
+
+    pub fn as_string(&self) -> Option<String> {
+        #[derive(Default)]
+        struct StringDiff {
+            diff: Option<String>,
+        }
+        impl<'a, T: std::fmt::Debug> DiffVisitor<'a, T> for StringDiff {
+            fn diff(&mut self, item: &'a T, left: usize, right: usize) -> bool {
+                match left.cmp(&right) {
+                    Ordering::Less => {
+                        self.diff = Some(format!("Missed result: {:?}", item));
+                        true
+                    },
+                    Ordering::Greater => {
+                        self.diff = Some(format!("Excessive result: {:?}", item));
+                        true
+                    },
+                    Ordering::Equal => false,
+                }
+            }
+        }
+        let mut d = StringDiff{ diff: None };
+        self.visit(&mut d);
+        d.diff
+    }
+
+    fn visit<'b, V: DiffVisitor<'b, T>>(&'b self, visitor: &mut V) {
+        for e in self.right_count.iter() {
+            let count = self.left_count.get(e.0).unwrap_or(&0);
+            if visitor.diff(e.0, *count, *e.1) { return }
+        }
+        for e in self.left_count.iter() {
+            let count = self.right_count.get(e.0).unwrap_or(&0);
+            if visitor.diff(e.0, *e.1, *count) { return }
         }
     }
-    for e in left.iter() {
-        if let Some(count) = right.get(e.0) {
-            match e.1.cmp(count) {
-                Ordering::Less => return Err(format!("Missed result: {:?}", e.0)),
-                Ordering::Greater => return Err(format!("Excessive result: {:?}", e.0)),
-                Ordering::Equal => {},
-            }
-        } else {
-            return Err(format!("Excessive result: {:?}", e.0));
-        }
-    }
-    Ok(())
 }
 
 #[macro_export]
 macro_rules! assert_eq_no_order {
     ($left:expr, $right:expr) => {
         {
-            assert!($crate::common::assert::vec_eq_no_order($left.iter(), $right.iter()) == Ok(()),
+            assert!($crate::common::assert::vec_eq_no_order($left.iter(), $right.iter()) == None,
                 "(left == right some order)\n  left: {:?}\n right: {:?}", $left, $right);
         }
     }
@@ -56,7 +111,7 @@ pub fn metta_results_eq<T: PartialEq + std::fmt::Debug>(
     match (left, right) {
         (Ok(left), Ok(right)) if left.len() == right.len() => {
             for (left, right) in left.iter().zip(right.iter()) {
-                if let Err(_) = vec_eq_no_order(left.iter(), right.iter()) {
+                if vec_eq_no_order(left.iter(), right.iter()).is_some() {
                     return false;
                 }
             }


### PR DESCRIPTION
Rework vec_eq_no_order function to be able compare atoms using custom equality logic. Allow finding out whether difference is present without printing the explanation.