### PR TITLE
Escape string atom before displaying it

### DIFF
--- a/lib/src/metta/runner/str.rs
+++ b/lib/src/metta/runner/str.rs
@@ -47,7 +47,7 @@ impl Grounded for Str {
 
 impl std::fmt::Display for Str {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "\"{}\"", self.0)
+        write!(f, "{:?}", self.0.as_str())
     }
 }
 

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -14,6 +14,7 @@ signal-hook = "0.3.17"
 pyo3 = { version = "0.19.2", features = ["auto-initialize"], optional = true }
 pep440_rs = { version = "0.3.11", optional = true }
 hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
+snailquote = "0.3.1"
 
 [[bin]]
 name = "metta-repl"


### PR DESCRIPTION
Use snailquote::unescape to fix REPL output when manipulating strings represented as atoms.

@DaddyWesker if you agree with change I would suggest the following work in addition:
- move `atom_into_string` from REPL into `hyperon::metta::runner::str` module and make it public
- use it instead of `strip_quotes` and `atom_to_string` inside `hyperon` core library
- check that all functions which use functions above works correctly after the change