### PR TITLE
Fix unescape

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.8.5"
 bitset = "0.1.2"
 dyn-fmt = "0.4.0"
 itertools = "0.13.0"
-snailquote = "0.3.1"
+unescaper = "0.1.5"
 
 # pkg_mgmt deps
 xxhash-rust = {version="0.8.7", features=["xxh3"], optional=true }

--- a/lib/src/metta/runner/str.rs
+++ b/lib/src/metta/runner/str.rs
@@ -2,7 +2,7 @@ use crate::*;
 use crate::common::collections::ImmutableString;
 use crate::serial;
 use crate::atom::serial::ConvertingSerializer;
-use snailquote::unescape;
+use unescaper;
 
 /// String type
 pub const ATOM_TYPE_STRING : Atom = sym!("String");
@@ -88,4 +88,29 @@ impl serial::ConvertingSerializer<Str> for StrSerializer {
 
 pub fn atom_to_string(atom: &Atom) -> String {
     unescape(&atom.to_string()).unwrap()
+}
+
+pub fn unescape(str: &str) -> unescaper::Result<String> {
+    unescaper::unescape(str).map(|mut s| {
+        s.remove(0);
+        s.pop();
+        s
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn str_display_escape() {
+        let s = Str::from_str("\\ \" \' \n \r \t \x1b abc");
+        assert_eq!(r#""\\ \" ' \n \r \t \u{1b} abc""#, s.to_string());
+    }
+
+    #[test]
+    fn str_unescape() {
+        let s = unescape(r#""\\ \" ' \n \r \t \u{1b} abc""#);
+        assert_eq!("\\ \" \' \n \r \t \x1b abc", s.unwrap());
+    }
 }

--- a/python/hyperon/stdlib.py
+++ b/python/hyperon/stdlib.py
@@ -48,7 +48,14 @@ class RegexMatchableObject(MatchableObject):
                 return [{"matched_pattern": S(pattern)}]
         return []
 
-def parseImpl():
+def parseImpl(atom, run_context):
+    try:
+        s = atom.get_object().content
+        if type(s) != str:
+            raise IncorrectArgumentError()
+        return [SExprParser(repr(s)[1:-1]).parse(run_context.tokenizer())]
+    except Exception as e:
+        raise IncorrectArgumentError()
 
 
 @register_atoms(pass_metta=True)
@@ -66,8 +73,7 @@ def text_ops(run_context):
 
     reprAtom = OperationAtom('repr', lambda a: [ValueAtom(repr(a), 'String')],
                              ['Atom', 'String'], unwrap=False)
-    parseAtom = OperationAtom('parse', lambda s: [SExprParser(str(s)[1:-1]).parse(run_context.tokenizer())],
-                              ['String', 'Atom'], unwrap=False)
+    parseAtom = OperationAtom('parse', lambda s: parseImpl(s, run_context), ['String', 'Atom'], unwrap=False)
     stringToCharsAtom = OperationAtom('stringToChars', lambda s: [E(*[ValueAtom(Char(c)) for c in str(s)[1:-1]])],
                                       ['String', 'Atom'], unwrap=False)
     charsToStringAtom = OperationAtom('charsToString', lambda a: [ValueAtom("".join([str(c)[1:-1] for c in a.get_children()]))],

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -14,7 +14,6 @@ signal-hook = "0.3.17"
 pyo3 = { version = "0.19.2", features = ["auto-initialize"], optional = true }
 pep440_rs = { version = "0.3.11", optional = true }
 hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
-snailquote = "0.3.1"
 
 [[bin]]
 name = "metta-repl"

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -39,7 +39,7 @@ pub mod metta_interface_mod {
     use pyo3::types::{PyTuple, PyString, PyBool, PyList, PyDict};
     use hyperon::common::collections::VecDisplay;
     use super::{exec_state_prepare, exec_state_should_break};
-    use snailquote::unescape;
+    use hyperon::metta::runner::str::unescape;
 
     /// Load the hyperon module, and get the "__version__" attribute
     pub fn get_hyperonpy_version() -> Result<String, String> {
@@ -240,7 +240,7 @@ pub mod metta_interface_mod {
                     match result.downcast::<PyList>() {
                         Ok(result_list) => {
                             Some(result_list.into_iter()
-                                .map(|atom| unescape(&atom.to_string()).unwrap())
+                                .map(|atom| { unescape(&atom.to_string()).unwrap() })
                                 .collect())
                         },
                         Err(_) => None
@@ -303,7 +303,6 @@ pub mod metta_interface_mod {
             }
         }
     }
-
 }
 
 /// The "no python" path involves a reimplementation of all of the MeTTa interface points calling MeTTa


### PR DESCRIPTION
Use https://crates.io/crates/unescaper to handle escape sequences like `\u{...}` properly as they are necessary to support Unicode strings. Implement Python `parse` function to accept only Python grounded string as a parameter.