### PR TITLE
Remove unnecessary calls of Atom::clone() in JSON encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ RUST_LOG=hyperon=debug cargo test
 
 Running benchmarks requires nightly toolchain so they can be run using:
 ```
-cargo +nightly bench
+cargo +nightly bench --features benchmark
 ```
 
 Generate docs:

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -44,3 +44,4 @@ variable_operation = [] # enables evaluation of the expressions which have
 online-test = [] # includes tests which require internet access
 git = ["git2", "pkg_mgmt"]
 pkg_mgmt = ["xxhash-rust", "serde", "serde_json", "semver"]
+benchmark = []

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,2 +1,4 @@
+#![cfg_attr(feature = "benchmark", feature(test))]
+
 pub mod space;
 pub mod metta;

--- a/lib/src/metta/runner/builtin_mods/json.rs
+++ b/lib/src/metta/runner/builtin_mods/json.rs
@@ -82,8 +82,11 @@ fn encode_dictspace(input: &Atom) -> Result<String, ExecError> {
     let mut first_atom = true;
     let mut res_str = "{".to_string();
     let _ = space.borrow().visit(&mut |atom: Cow<Atom>| {
+        if err.is_some() {
+            return;
+        }
         match TryInto::<&ExpressionAtom>::try_into(atom.as_ref()) {
-            Ok(expr) => if err.is_none() && expr.children().len() == 2 {
+            Ok(expr) => if expr.children().len() == 2 {
                 match extract_key_value_pair(&atom) {
                     Ok(encoded_key_value) => {
                         if !first_atom {

--- a/lib/src/metta/runner/builtin_mods/json.rs
+++ b/lib/src/metta/runner/builtin_mods/json.rs
@@ -85,15 +85,15 @@ impl From<JSONError> for ExecError {
 }
 
 fn encode_list<W: Write>(writer: &mut W, input: &[Atom]) -> Result<(), JSONError> {
-    writer.write("[".as_bytes())?;
+    writer.write(b"[")?;
     if !input.is_empty() {
         encode_atom(writer, input.first().unwrap())?;
         for atom in &input[1..] {
-            writer.write(", ".as_bytes())?;
+            writer.write(b", ")?;
             encode_atom(writer, atom)?;
         }
     }
-    writer.write("]".as_bytes())?;
+    writer.write(b"]")?;
     Ok(())
 }
 
@@ -106,7 +106,7 @@ fn extract_key_value_pair<W: Write>(writer: &mut W, atom: &Atom) -> Result<(), J
     let value = res_expr.children().get(1)
         .ok_or("Key/value pair is expected")?;
     writer.write(key.as_bytes())?;
-    writer.write(":".as_bytes())?;
+    writer.write(b":")?;
     encode_atom(writer, value)?;
     Ok(())
 }
@@ -115,7 +115,7 @@ fn encode_dictspace<W: Write>(writer: &mut W, input: &Atom) -> Result<(), JSONEr
     let space = Atom::as_gnd::<DynSpace>(input).unwrap();
     let mut result = Ok(());
     let mut first_atom = true;
-    writer.write("{".as_bytes())?;
+    writer.write(b"{")?;
     let _ = space.borrow().visit(&mut |atom: Cow<Atom>| {
         if result.is_err() {
             return;
@@ -123,7 +123,7 @@ fn encode_dictspace<W: Write>(writer: &mut W, input: &Atom) -> Result<(), JSONEr
         result = match TryInto::<&ExpressionAtom>::try_into(atom.as_ref()) {
             Ok(expr) if expr.children().len() == 2 => {
                 let r = if !first_atom {
-                    writer.write(", ".as_bytes()).map(|_| ()).map_err(|e| e.into())
+                    writer.write(b", ").map(|_| ()).map_err(|e| e.into())
                 } else {
                     first_atom = false;
                     Ok(())
@@ -136,7 +136,7 @@ fn encode_dictspace<W: Write>(writer: &mut W, input: &Atom) -> Result<(), JSONEr
     match result {
         Err(err) => Err(err),
         Ok(()) => {
-            writer.write("}".as_bytes())?;
+            writer.write(b"}")?;
             Ok(())
         }
     }
@@ -170,7 +170,7 @@ fn encode_atom<W: Write>(writer: &mut W, input: &Atom) -> Result<(), JSONError> 
         // Symbols will use additional sym!: prefix to separate them from regular strings. null is a
         // symbol too, but it should remain "null" after encoding so decoder will see it like Value::Null instance.
         Atom::Symbol(sym) if sym.name() == "null" => {
-            writer.write("null".as_bytes()).map(|_| ()).map_err(|e| e.into())
+            writer.write(b"null").map(|_| ()).map_err(|e| e.into())
         },
         Atom::Symbol(sym) => {
             let sym_name = "sym!:".to_string() + sym.name();

--- a/lib/src/metta/runner/builtin_mods/json.rs
+++ b/lib/src/metta/runner/builtin_mods/json.rs
@@ -194,7 +194,7 @@ fn json_encode(args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
     let mut buffer: Vec<u8> = Vec::new();
     encode_atom(&mut buffer, input)?;
     let json = String::from_utf8(buffer)
-        .map_err(|err| ExecError::Runtime(format!("Encode space failed: {}", err)))?;
+        .map_err(|err| ExecError::Runtime(format!("Encode atom failed: {}", err)))?;
     Ok(vec![Atom::gnd(Str::from_string(json))])
 }
 

--- a/lib/src/metta/runner/builtin_mods/json.rs
+++ b/lib/src/metta/runner/builtin_mods/json.rs
@@ -268,4 +268,30 @@ mod tests {
             vec![UNIT_ATOM],
         ]));
     }
+
+    #[cfg(feature="benchmark")]
+    mod benchmarks {
+        extern crate test;
+
+        use test::Bencher;
+        use hyperon_atom::Atom;
+        use hyperon_space::DynSpace;
+        use crate::space::grounding::*;
+        use crate::metta::runner::str::Str;
+        use super::super::json_encode;
+
+        #[bench]
+        fn bench_json_encode(bencher: &mut Bencher) {
+            let mut space = GroundingSpace::new();
+            for _i in 1..1000 {
+                space.add(Atom::expr([Atom::gnd(Str::from_str("some-key")), Atom::sym("some-value")]));
+            }
+            let space = Atom::gnd(DynSpace::new(space));
+            bencher.iter(|| {
+                let result = json_encode(&[space.clone()]);
+                assert!(result.is_ok());
+            })
+        }
+    }
 }
+


### PR DESCRIPTION
Remove unnecessary atom copying in JSON encoder. Make code more compact by using `map` and `map_err` instead of `match`.