### PR TITLE
Replace BadRetType by BadType when function return type is not as expected

### DIFF
--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -1383,7 +1383,7 @@ fn interpret_args(args_: Atom, bindings: Bindings) -> MettaResult {
         if types_tail.is_empty() {
             match match_types(&types_head, &ret_type, bindings) {
                 Ok(matches) => Box::new(matches.map(move |bindings| (return_atom(Atom::expr([Atom::sym("Ok"), Atom::Expression(args.clone())])), bindings))),
-                Err(nomatch) => Box::new(nomatch.map(move |bindings| (return_atom(error_atom(atom.clone(), BAD_RET_TYPE_SYMBOL)), bindings))),
+                Err(nomatch) => Box::new(nomatch.map(move |bindings| (return_atom(error_atom(atom.clone(), BAD_TYPE_SYMBOL)), bindings))),
             }
         } else {
             once((return_atom(error_atom(atom, INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL)), bindings))

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -25,7 +25,6 @@ pub const ARROW_SYMBOL : Atom = metta_const!(->);
 pub const ERROR_SYMBOL : Atom = metta_const!(Error);
 pub const BAD_TYPE_SYMBOL : Atom = metta_const!(BadType);
 pub const BAD_ARG_TYPE_SYMBOL : Atom = metta_const!(BadArgType);
-pub const BAD_RET_TYPE_SYMBOL : Atom = metta_const!(BadRetType);
 pub const INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL : Atom = metta_const!(IncorrectNumberOfArguments);
 pub const NOT_REDUCIBLE_SYMBOL : Atom = metta_const!(NotReducible);
 pub const STACK_OVERFLOW_SYMBOL : Atom = metta_const!(StackOverflow);

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -29,14 +29,6 @@
   (@return "Instance of the BadArgType error atom"))
 (: BadArgType (-> Number Type Type ErrorDescription))
 
-(@doc BadRetType
-  (@desc "BadRetType error constructor")
-  (@params (
-    (@param "Expected type")
-    (@param "Actual type")))
-  (@return "Instance of the BadRetType error atom"))
-(: BadRetType (-> Type Type ErrorDescription))
-
 (: IncorrectNumberOfArguments ErrorDescription)
 
 (@doc Error


### PR DESCRIPTION
BadRetType looks excessive in the examples we have.